### PR TITLE
feat: common-footer 추가

### DIFF
--- a/src/app/test-footer/page.tsx
+++ b/src/app/test-footer/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import Footer from '../../components/Footer/Footer';
+
+export default function Page() {
+  return (
+    <div className="min-h-screen flex flex-col justify-end bg-gray-50">
+      {/* Footer 테스트 */}
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Footer from './Footer';
+
+const meta: Meta<typeof Footer> = {
+  title: 'Components/Footer',
+  component: Footer,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Footer>;
+
+export const Default: Story = {
+  render: () => <Footer />,
+};

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,0 +1,134 @@
+import Link from 'next/link';
+import Image from 'next/image';
+
+export default function Footer() {
+  return (
+    <footer className="bg-[#112211] text-[#676767]">
+      <div className="mx-auto w-full pt-8 pb-16 flex flex-col gap-4 px-[max(20px,5%)]">
+        {/* 모바일 (<768px): 저작권 + 개인정보처리방침 */}
+        <div className="flex justify-between w-full items-center md:hidden">
+          <span className="font-normal text-lg leading-none tracking-normal whitespace-nowrap">
+            ©codeit-2023
+          </span>
+          <nav className="flex gap-6 text-lg">
+            <Link
+              href="https://www.codeit.kr/terms/PRIVACY_POLICY"
+              className="hover:text-[#DDDDDD] transition-colors duration-300 whitespace-nowrap"
+            >
+              Privacy Policy
+            </Link>
+            <Link
+              href="https://www.codeit.kr/faq"
+              className="hover:text-[#DDDDDD] transition-colors duration-300 whitespace-nowrap"
+            >
+              FAQ
+            </Link>
+          </nav>
+        </div>
+
+        {/* 모바일 (<768px): SNS */}
+        <div className="flex justify-center items-center gap-4 w-full md:hidden">
+          {[
+            {
+              href: 'https://www.facebook.com/codeit.kr/',
+              alt: 'Facebook',
+              icon: '/icon/mono/facebook.png',
+            },
+            {
+              href: 'https://x.com/CodeitKr/status/1628942846601605120',
+              alt: 'Twitter',
+              icon: '/icon/mono/twitter.png',
+            },
+            {
+              href: 'https://www.youtube.com/channel/UCCM79CPm2WbBYTRaiNEExbg',
+              alt: 'YouTube',
+              icon: '/icon/mono/youtube.png',
+            },
+            {
+              href: 'https://www.instagram.com/codeit_kr/',
+              alt: 'Instagram',
+              icon: '/icon/mono/instagram.png',
+            },
+          ].map(({ href, alt, icon }) => (
+            <a
+              key={alt}
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={alt}
+            >
+              <Image
+                src={icon}
+                alt={alt}
+                width={20}
+                height={20}
+                className="hover:opacity-80"
+              />
+            </a>
+          ))}
+        </div>
+
+        {/* 태블릿+PC (≥768px) */}
+        <div className="hidden md:flex justify-between items-center w-full">
+          <span className="font-normal text-lg leading-none tracking-normal whitespace-nowrap">
+            ©codeit-2023
+          </span>
+          <nav className="flex gap-6 text-lg">
+            <Link
+              href="/privacy"
+              className="hover:text-[#DDDDDD] transition-colors duration-300"
+            >
+              Privacy Policy
+            </Link>
+            <Link
+              href="/faq"
+              className="hover:text-[#DDDDDD] transition-colors duration-300"
+            >
+              FAQ
+            </Link>
+          </nav>
+          <div className="flex gap-4">
+            {[
+              {
+                href: 'https://www.facebook.com/codeit.kr/',
+                alt: 'Facebook',
+                icon: '/icon/mono/facebook.png',
+              },
+              {
+                href: 'https://x.com/CodeitKr/status/1628942846601605120',
+                alt: 'Twitter',
+                icon: '/icon/mono/twitter.png',
+              },
+              {
+                href: 'https://www.youtube.com/channel/UCCM79CPm2WbBYTRaiNEExbg',
+                alt: 'YouTube',
+                icon: '/icon/mono/youtube.png',
+              },
+              {
+                href: 'https://www.instagram.com/codeit_kr/',
+                alt: 'Instagram',
+                icon: '/icon/mono/instagram.png',
+              },
+            ].map(({ href, alt, icon }) => (
+              <a
+                key={alt}
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={alt}
+              >
+                <Image
+                  src={icon}
+                  alt={alt}
+                  width={20}
+                  height={20}
+                  className="hover:opacity-80"
+                />
+              </a>
+            ))}
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Footer/TestFooter.tsx
+++ b/src/components/Footer/TestFooter.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import Footer from './Footer';
+
+export default function TestFooter() {
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col justify-end">
+      {/* Footer 테스트 */}
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## PR 개요

- Footer 컴포넌트 추가
- TestFooter.tsx 파일 참고해서 사용하도록 작업

## 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링

## 상세 설명

- 사이트 하단에 저작권 정보, 개인정보처리방침, FAQ, SNS 링크를 표시하는 UI 컴포넌트
- 모바일 (<768px): 2단으로 구성
  - 저작권 + Privacy/FAQ 링크
  - SNS 아이콘
- 태블릿+PC (≥768px): 1단으로 구성
  - 저작권 + Privacy/FAQ + SNS 아이콘를 한 줄에 배치

## 관련 이슈

- closes #이슈번호

## Attachment

<img width="1895" height="198" alt="image" src="https://github.com/user-attachments/assets/b2171469-25b0-4d01-8317-6111e83d6e5d" />