### PR TITLE
feat: MyInfo페이지 UI추가, Profile 공통 컴포넌트 추가

### DIFF
--- a/src/app/Profile/MyInfo/page.tsx
+++ b/src/app/Profile/MyInfo/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+import FormInput from '@/components/Input/FormInput';
+import Header from '@/app/Profile/_components/MypageHeader/MypageHeader';
+import { useInputValue } from '@/hooks/useInputValue';
+// import Nodata from '@/app/Profile/_components/Nodata/Nodata';
+export default function MyInfo() {
+  const [form, handleChange] = useInputValue({
+    nickname: '',
+    email: '',
+    password: '',
+    passwordConfirm: '',
+  });
+
+  return (
+    <div>
+      <Header
+        title="제목"
+        type="button"
+        buttonText="저장하기"
+        onClick={() => {
+          console.log('저장하기');
+        }}
+      />
+      <form>
+        <fieldset>
+          <FormInput
+            id="nickname"
+            name="nickname"
+            type="nickname"
+            labelText="닉네임"
+            placeholder="닉네임을 입력하세요"
+            value={form.nickname}
+            onChange={handleChange}
+          />
+          <FormInput
+            id="email"
+            name="email"
+            type="email"
+            labelText="이메일"
+            placeholder="이메일을 입력하세요"
+            value={form.email}
+            onChange={handleChange}
+          />
+          <FormInput
+            id="password"
+            name="password"
+            type="password"
+            labelText="비밀번호"
+            placeholder="비밀번호를 입력하세요"
+            value={form.password}
+            onChange={handleChange}
+          />
+          <FormInput
+            id="passwordConfirm"
+            name="passwordConfirm"
+            type="passwordConfirm"
+            labelText="비밀번호 확인"
+            placeholder="비밀번호를 다시 입력하세요"
+            value={form.passwordConfirm}
+            onChange={handleChange}
+            passwordValue={form.password}
+          />
+        </fieldset>
+      </form>
+    </div>
+  );
+}

--- a/src/app/Profile/_components/MypageHeader/MypageHeader.tsx
+++ b/src/app/Profile/_components/MypageHeader/MypageHeader.tsx
@@ -1,0 +1,37 @@
+import clsx from 'clsx';
+import Button from '@/components/Button';
+type HeaderType = {
+  title: string;
+  type?: 'button' | 'filter' | null;
+  buttonText?: string;
+  onClick?: () => void;
+};
+export default function MypageHeader({
+  title,
+  type = null,
+  buttonText,
+  onClick,
+}: HeaderType) {
+  return (
+    <div
+      className={clsx(
+        'flex justify-between items-center sticky top-0 h-[50px] items-start',
+        'xs:h-[62px]'
+      )}
+    >
+      <h2 className={clsx('text-3xl font-bold')}>{title}</h2>
+      {/* 기본형 null , button과 filter 타입 선택 가능 */}
+      {type === 'button' ? (
+        <Button
+          color="buttonPrimary"
+          onClick={onClick ?? (() => {})}
+          className="h-12 px-8 rounded-sm"
+        >
+          {buttonText}
+        </Button>
+      ) : type === 'filter' ? (
+        <select></select>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/Profile/_components/MypageHeader/TestMypageHeader.tsx
+++ b/src/app/Profile/_components/MypageHeader/TestMypageHeader.tsx
@@ -1,0 +1,20 @@
+import MypageHeader from '@/app/Profile/_components/MypageHeader/MypageHeader';
+
+export default function TestMypageHeader() {
+  return (
+    <div>
+      {/* 기본형: 타이틀만 있는 경우 title 한개만 써줌*/}
+      <MypageHeader title="마이페이지 타이틀" />
+
+      {/* 버튼형: 버튼과 타이틀 있는 경우 */}
+      {/* title써주고 type="button"으로 지정,  buttonText에 버튼에 들어갈 텍스트 적어줌, onClick에 기능 작성  */}
+      <MypageHeader
+        title="마이페이지 타이틀"
+        type="button"
+        buttonText="버튼"
+        onClick={() => {}}
+      />
+      {/* filter의 경우 이후 개발 예정 */}
+    </div>
+  );
+}

--- a/src/app/Profile/_components/Nodata/Nodata.tsx
+++ b/src/app/Profile/_components/Nodata/Nodata.tsx
@@ -1,0 +1,25 @@
+import clsx from 'clsx';
+import Image from 'next/image';
+
+export default function Nodata() {
+  return (
+    <div
+      className={clsx(
+        'flex flex-col items-center pt-[60px]',
+        'xs:pt-14',
+        'md:pt-[86px]'
+      )}
+    >
+      <Image
+        width={200}
+        height={200}
+        src="/images/empty.svg"
+        alt="데이터 없음"
+        className="md:w-[240px] md:h-[240px]"
+      />
+      <p className="pt-5 text-2xl font-medium text-gray-700 ">
+        아직 등록한 체험이 없어요
+      </p>
+    </div>
+  );
+}

--- a/src/components/chips/TestChips.tsx
+++ b/src/components/chips/TestChips.tsx
@@ -1,14 +1,18 @@
-import Chips from "@/components/chips/Chips";
+import Chips from '@/components/Chips/Chips';
 
-export default  function ChipTest(){
-    // color옵션 'white' 이 기본 'blue' | 'gray' | 'orange' | 'red'중 선택 사용
-    // variant옵션 'normal'이 기본, round 선택 가능
-    <>
+export default function ChipTest() {
+  // color옵션 'white' 이 기본 'blue' | 'gray' | 'orange' | 'red'중 선택 사용
+  // variant옵션 'normal'이 기본, round 선택 가능
+  <>
     <Chips color="white">선택</Chips>
     <Chips color="blue">선택</Chips>
     <Chips color="gray">선택</Chips>
     <Chips color="orange">선택</Chips>
-    <Chips color="orange" variant="round">예약확정</Chips>
-    <Chips color="red" variant="round">예약거절</Chips>
-    </>
+    <Chips color="orange" variant="round">
+      예약확정
+    </Chips>
+    <Chips color="red" variant="round">
+      예약거절
+    </Chips>
+  </>;
 }

--- a/src/components/datepicker/DatePicker.tsx
+++ b/src/components/datepicker/DatePicker.tsx
@@ -32,7 +32,6 @@ export default function DatePickerComponent({ className }: DatePickerType) {
           'md:text-lg md:w-[374px] md:py-[15px]',
           'xs:w-[149px] xs:py-[17px]'
         )}
-        // 하이트 56 44
       />
       <Image
         src="/icon/calendar.svg"


### PR DESCRIPTION
## PR 개요

- myinfo 페이지와 프로필에서 공통으로 쓰이는 헤더와 데이터 없을때 페이지 작업

## 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링

## 상세 설명

myinfo 페이지 ui 작업 라벨 관련 수정사항 있음.

프로필에서 공통헤더 타이틀만 있는 경우, 버튼이 있는 경우, filter있는 경우 나눠놓음 -> 추후 select 추가해 filter 작업 완료 예정 

## 관련 이슈

- closes #이슈번호

## Attachment
<img width="1525" height="440" alt="image" src="https://github.com/user-attachments/assets/ed3189bd-023c-4ea9-b850-dc1368e0ce7c" />
<img width="1522" height="459" alt="image" src="https://github.com/user-attachments/assets/e9ba06c4-9982-4b1f-8410-0ead4716e8d7" />

