### PR TITLE
fix: Input 사용자 정의 스타일로 수정

### DIFF
--- a/src/components/Input/CustomInput.tsx
+++ b/src/components/Input/CustomInput.tsx
@@ -12,6 +12,12 @@ type CustomInputProps = {
   placeholder?: string;
   value?: string | number;
   onChange?: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+
+  // 사용자 스타일 수정 prop
+  wrapperClassName?: string;
+  labelClassName?: string;
+  labelUnstyled?: boolean; //기본 스타일 제거
+  inputClassName?: string;
 };
 
 export default function CustomInput({
@@ -23,10 +29,21 @@ export default function CustomInput({
   placeholder,
   value,
   onChange,
+  wrapperClassName,
+  labelClassName,
+  labelUnstyled = false,
+  inputClassName,
 }: CustomInputProps) {
   return (
-    <div className="w-full mb-4">
-      {labelText && <Label id={id} text={labelText} />}
+    <div className={`w-full mb-4 ${wrapperClassName || ''}`}>
+      {labelText && (
+        <Label
+          id={id}
+          text={labelText}
+          className={labelClassName}
+          unstyled={labelUnstyled}
+        />
+      )}
       {variant === 'textarea' ? (
         <textarea
           id={id}
@@ -34,10 +51,11 @@ export default function CustomInput({
           placeholder={placeholder}
           value={value as string}
           onChange={onChange as (e: ChangeEvent<HTMLTextAreaElement>) => void}
-          className="w-full px-5 py-4 rounded-md border
+          className={`w-full px-5 py-4 rounded-md border
             border-gray-700 focus:outline-none
             min-h-[240px]
-            text-lg text-black placeholder-gray-600"
+            text-lg text-black placeholder-gray-600
+            ${inputClassName || ''}`}
         />
       ) : (
         <input
@@ -47,9 +65,10 @@ export default function CustomInput({
           placeholder={placeholder}
           value={value}
           onChange={onChange as (e: ChangeEvent<HTMLInputElement>) => void}
-          className="w-full px-5 py-4 rounded-md border
+          className={`w-full px-5 py-4 rounded-md border
             border-gray-700 focus:outline-none
-            text-lg text-black placeholder-gray-600"
+            text-lg text-black placeholder-gray-600
+            ${inputClassName || ''}`}
         />
       )}
     </div>

--- a/src/components/Input/FormInput.tsx
+++ b/src/components/Input/FormInput.tsx
@@ -19,7 +19,14 @@ type FormInputProps = {
   placeholder?: string;
   value: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
-  passwordValue?: string; // passwordConfirm 검증용
+  passwordValue?: string;
+
+  // 사용자 스타일 수정 prop
+  wrapperClassName?: string;
+  labelClassName?: string;
+  labelUnstyled?: boolean; //기본 스타일 제거
+  inputClassName?: string;
+  errorClassName?: string;
 };
 
 export default function FormInput({
@@ -31,8 +38,12 @@ export default function FormInput({
   value,
   onChange,
   passwordValue,
+  wrapperClassName,
+  labelClassName,
+  labelUnstyled = false,
+  inputClassName,
+  errorClassName,
 }: FormInputProps) {
-  //비밀번호 토글
   const [visible, setVisible] = useState(false);
   const changeType =
     type === 'password' || type === 'passwordConfirm'
@@ -47,7 +58,6 @@ export default function FormInput({
     validate(e.target.value);
   };
 
-  //Input 최대 길이
   const getMaxLength = (t: string) => {
     switch (t) {
       case 'email':
@@ -63,8 +73,13 @@ export default function FormInput({
   };
 
   return (
-    <div className="w-full mb-4">
-      <Label id={id} text={labelText} />
+    <div className={`w-full mb-4 ${wrapperClassName || ''}`}>
+      <Label
+        id={id}
+        text={labelText}
+        className={labelClassName}
+        unstyled={labelUnstyled}
+      />
       <div className="relative">
         <input
           id={id}
@@ -76,11 +91,10 @@ export default function FormInput({
           onBlur={handleBlur}
           maxLength={getMaxLength(type)}
           className={`w-full px-5 py-4 rounded-md border
-          border-gray-300 focus:outline-none focus:border-gray-500
-          text-lg text-black
-          placeholder-gray-500
-            ${error ? 'border-red focus:outline-none focus:border-red' : 'border-gray-300 focus:ring-blue-500'}
-          `}
+            border-gray-300 focus:outline-none focus:border-gray-500
+            text-lg text-black placeholder-gray-500
+            ${error ? 'border-red focus:border-red' : 'border-gray-300 focus:ring-blue-500'}
+            ${inputClassName || ''}`}
         />
         {(type === 'password' || type === 'passwordConfirm') && (
           <button
@@ -101,7 +115,11 @@ export default function FormInput({
           </button>
         )}
       </div>
-      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+      {error && (
+        <p className={`mt-1 text-xs text-red-500 ${errorClassName || ''}`}>
+          {error}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/Input/InputTEST.tsx
+++ b/src/components/Input/InputTEST.tsx
@@ -37,7 +37,7 @@ export default function InputTEST() {
       <FormInput
         id="nickname"
         name="nickname"
-        type="nickname"
+        type="text" // nickname → 표준 type 보정
         labelText="닉네임"
         placeholder="닉네임을 입력하세요"
         value={form.nickname}
@@ -55,12 +55,25 @@ export default function InputTEST() {
       <FormInput
         id="passwordConfirm"
         name="passwordConfirm"
-        type="passwordConfirm"
+        type="password" // passwordConfirm → password 로 처리
         labelText="비밀번호 확인"
         placeholder="비밀번호를 다시 입력하세요"
         value={form.passwordConfirm}
         onChange={handleChange}
         passwordValue={form.password}
+      />
+      <FormInput
+        id="passwordConfirm"
+        name="passwordConfirm"
+        type="password" // passwordConfirm → password 로 처리
+        labelText="비밀번호 확인"
+        placeholder="비밀번호를 다시 입력하세요"
+        value={form.passwordConfirm}
+        onChange={handleChange}
+        passwordValue={form.password}
+        inputClassName="border-gray-700 bg-white"
+        labelClassName="text-black font-bold"
+        labelUnstyled
       />
 
       {/* ---------------- 검색 ---------------- */}
@@ -74,34 +87,39 @@ export default function InputTEST() {
       />
 
       {/* ---------------- 커스텀 입력 ---------------- */}
-      <h2 className="text-lg font-bold">일반 입력</h2>
-      <CustomInput
-        id="title"
-        name="title"
-        type="text"
-        labelText="제목"
-        placeholder="제목을 입력하세요"
-        value={form.title}
-        // onChange={handleChange}
-      />
-      <CustomInput
-        id="price"
-        name="price"
-        type="number"
-        labelText="가격"
-        placeholder="가격"
-        value={form.price}
-        // onChange={handleChange}
-      />
-      <CustomInput
-        id="address"
-        name="address"
-        type="text"
-        labelText="주소"
-        placeholder="주소를 입력해주세요"
-        value={form.address}
-        // onChange={handleChange}
-      />
+      <div className="bg-blue-pale">
+        <h2 className="text-lg font-bold">일반 입력</h2>
+        <CustomInput
+          id="title"
+          name="title"
+          type="text"
+          labelText="제목"
+          placeholder="제목을 입력하세요"
+          value={form.title}
+          onChange={handleChange}
+          inputClassName="border-gray-700 bg-white"
+          labelClassName="text-black font-bold"
+          labelUnstyled
+        />
+        <CustomInput
+          id="price"
+          name="price"
+          type="number"
+          labelText="가격"
+          placeholder="가격"
+          value={form.price}
+          onChange={handleChange}
+        />
+        <CustomInput
+          id="address"
+          name="address"
+          type="text"
+          labelText="주소"
+          placeholder="주소를 입력해주세요"
+          value={form.address}
+          onChange={handleChange}
+        />
+      </div>
 
       {/* ---------------- TextArea ---------------- */}
       <h2 className="text-lg font-bold">긴 텍스트 입력</h2>
@@ -112,7 +130,28 @@ export default function InputTEST() {
         labelText="설명"
         placeholder="설명을 입력하세요"
         value={form.description}
-        // onChange={handleChange}
+        onChange={handleChange}
+      />
+
+      <FormInput
+        id="email"
+        name="email"
+        type="email"
+        labelText="이메일"
+        value={form.email}
+        onChange={handleChange}
+        labelClassName="text-blue-600"
+      />
+
+      <CustomInput
+        id="nickname"
+        name="nickname"
+        labelText="닉네임"
+        value={form.nickname}
+        placeholder="닉네임을 입력하세요"
+        onChange={handleChange}
+        labelClassName="text-red-500 text-xl italic"
+        labelUnstyled
       />
     </div>
   );

--- a/src/components/Input/Label.tsx
+++ b/src/components/Input/Label.tsx
@@ -1,13 +1,24 @@
 type LabelProps = {
   id: string;
   text: string;
+  className?: string;
+  unstyled?: boolean;
 };
 
-export default function Label({ id, text }: LabelProps) {
+export default function Label({
+  id,
+  text,
+  className = '',
+  unstyled = false,
+}: LabelProps) {
   return (
     <label
       htmlFor={id}
-      className="block mb-1 text-sm font-medium text-gray-700"
+      className={
+        unstyled
+          ? className
+          : `block mb-1 text-sm font-medium text-gray-700 ${className}`
+      }
     >
       {text}
     </label>


### PR DESCRIPTION
## PR 개요
- Input 사용자 정의 스타일로 수정 가능하도록 코드 수정

## 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링

## 상세 설명
```  // 사용자 스타일 수정 prop
  wrapperClassName?: string;
  labelClassName?: string;
  labelUnstyled?: boolean; //기본 스타일 제거
  inputClassName?: string;```
- 코드 추가

## 관련 이슈

- closes #이슈번호

## Attachment

<img width="1573" height="544" alt="스크린샷 2025-10-02 17 49 57" src="https://github.com/user-attachments/assets/96523e8e-3a18-43dd-b011-a89dd14be335" />
<img width="1564" height="122" alt="스크린샷 2025-10-02 17 50 10" src="https://github.com/user-attachments/assets/11f863bb-4117-47e2-9530-a31a2e727a19" />
<img width="1571" height="324" alt="스크린샷 2025-10-02 17 50 51" src="https://github.com/user-attachments/assets/20a469b7-272b-4fe2-9d1b-8b261918ed4e" />
<img width="1590" height="334" alt="스크린샷 2025-10-02 17 51 01" src="https://github.com/user-attachments/assets/6bde06e5-890e-45bc-8bbd-ff63cad017e4" />
<img width="1576" height="203" alt="스크린샷 2025-10-02 17 51 09" src="https://github.com/user-attachments/assets/ff4d241c-5e5c-4f52-82c2-10cde7b65353" />
